### PR TITLE
 Asynchronous experimentation

### DIFF
--- a/examples/set.go
+++ b/examples/set.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sreevani871/go-scientist"
+	"github.com/technoweenie/go-scientist"
 )
 
 var (

--- a/examples/set.go
+++ b/examples/set.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/technoweenie/go-scientist"
+	"github.com/Sreevani871/go-scientist"
 )
 
 var (

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -1,6 +1,7 @@
 package scientist
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -8,10 +9,10 @@ import (
 
 func TestExperimentMatch(t *testing.T) {
 	e := New("match")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
 
@@ -30,7 +31,7 @@ func TestExperimentMatch(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}
@@ -46,10 +47,10 @@ func TestExperimentMatch(t *testing.T) {
 
 func TestExperimentMismatchNoReturn(t *testing.T) {
 	e := New("match")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 2, nil
 	})
 
@@ -68,7 +69,7 @@ func TestExperimentMismatchNoReturn(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}
@@ -84,10 +85,10 @@ func TestExperimentMismatchNoReturn(t *testing.T) {
 
 func TestExperimentMismatchWithReturn(t *testing.T) {
 	e := New("match")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 2, nil
 	})
 
@@ -108,7 +109,7 @@ func TestExperimentMismatchWithReturn(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != nil {
 		t.Errorf("Unexpected control value: %v (%T)", v, v)
 	}
@@ -127,10 +128,10 @@ func TestExperimentRunBefore(t *testing.T) {
 	before := false
 
 	e := New("run")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
 
@@ -144,7 +145,7 @@ func TestExperimentRunBefore(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}
@@ -166,10 +167,10 @@ func TestExperimentDisabledRunBefore(t *testing.T) {
 	runIf := false
 
 	e := New("run")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
 
@@ -183,7 +184,7 @@ func TestExperimentDisabledRunBefore(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}
@@ -201,7 +202,7 @@ func TestExperimentEmptyRunBefore(t *testing.T) {
 	runIf := false
 
 	e := New("run")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
 
@@ -215,7 +216,7 @@ func TestExperimentEmptyRunBefore(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}
@@ -232,11 +233,11 @@ func TestExperimentEmptyRunBefore(t *testing.T) {
 func TestExperimentRunIfError(t *testing.T) {
 	reported := false
 	e := New("run")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
 
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		t.Errorf("did not expect to run experiment if RunIf() returns error")
 		return 1, nil
 	})
@@ -267,7 +268,7 @@ func TestExperimentRunIfError(t *testing.T) {
 		return true, fmt.Errorf("run_if")
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != nil {
 		t.Errorf("unexpected result: %v", v)
 	}
@@ -285,10 +286,10 @@ func TestExperimentRunIfError(t *testing.T) {
 
 func TestExperimentSkipCompareMismatchedValues(t *testing.T) {
 	e := New("ignore")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 2, nil
 	})
 	e.Compare(func(control, candidate interface{}) (bool, error) {
@@ -306,7 +307,7 @@ func TestExperimentSkipCompareMismatchedValues(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}
@@ -322,10 +323,10 @@ func TestExperimentSkipCompareMismatchedValues(t *testing.T) {
 
 func TestExperimentSkipCompareMismatchedErrors(t *testing.T) {
 	e := New("ignore")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 1, errors.New("try")
 	})
 	e.Compare(func(control, candidate interface{}) (bool, error) {
@@ -343,7 +344,7 @@ func TestExperimentSkipCompareMismatchedErrors(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}
@@ -359,10 +360,10 @@ func TestExperimentSkipCompareMismatchedErrors(t *testing.T) {
 
 func TestExperimentSkipCompareSameErrors(t *testing.T) {
 	e := New("ignore")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, errors.New("ok")
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 1, errors.New("ok")
 	})
 	e.Compare(func(control, candidate interface{}) (bool, error) {
@@ -380,7 +381,7 @@ func TestExperimentSkipCompareSameErrors(t *testing.T) {
 		return nil
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Sreevani871/go-scientist
+
+go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Sreevani871/go-scientist
+module github.com/technoweenie/go-scientist
 
 go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/technoweenie/go-scientist
+module github.com/Sreevani871/go-scientist
 
 go 1.17

--- a/publish_test.go
+++ b/publish_test.go
@@ -1,16 +1,17 @@
 package scientist
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
 
 func TestPublish(t *testing.T) {
 	e := New("publish")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 2, nil
 	})
 
@@ -31,7 +32,7 @@ func TestPublish(t *testing.T) {
 		t.Errorf("result errors reported :(")
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}
@@ -51,10 +52,10 @@ func TestPublish(t *testing.T) {
 
 func TestPublishWithErrors(t *testing.T) {
 	e := New("publish")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 2, nil
 	})
 	e.BeforeRun(func() error {
@@ -108,7 +109,7 @@ func TestPublishWithErrors(t *testing.T) {
 		}
 	})
 
-	v, err := e.Run()
+	v, err := e.Run(context.Background())
 	if v != 1 {
 		t.Errorf("Unexpected control value: %d", v)
 	}

--- a/scientist.go
+++ b/scientist.go
@@ -1,7 +1,11 @@
 package scientist
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"math/rand"
+	"sync"
 	"time"
 )
 
@@ -48,14 +52,60 @@ func (r Result) IsIgnored() bool {
 	return len(r.Ignored) > 0
 }
 
-func Run(e *Experiment, name string) Result {
+func RunAsync(ctx context.Context, e *Experiment, controlBehavior string) Result {
+	var errors []ResultError
+	if err := e.beforeRun(); err != nil {
+		errors = append(errors, e.resultErr("before_run", err))
+	}
+
+	behaviors := e.Shuffle(controlBehavior, false)
+	control, candidates := runAsync(ctx, e, behaviors, controlBehavior)
+	r := gatherResult(e, control, candidates, controlBehavior)
+	r.Errors = append(r.Errors, errors...)
+	if err := e.publisher(r); err != nil {
+		r.Errors = append(r.Errors, e.resultErr("publish", err))
+	}
+
+	if len(r.Errors) > 0 {
+		e.errorReporter(r.Errors...)
+	}
+
+	return r
+}
+func RunAsyncCandidatesOnly(ctx context.Context, e *Experiment, controlBehavior string) Result {
+	r := Result{Experiment: e}
+	var errors []ResultError
+	if err := e.beforeRun(); err != nil {
+		errors = append(r.Errors, e.resultErr("before_run", err))
+	}
+	r.Control = observe(ctx, e, controlBehavior, e.behaviors[controlBehavior])
+	r.Errors = errors
+
+	go func(ctx context.Context, e *Experiment) {
+		behaviors := e.Shuffle(controlBehavior, true)
+		_, candidates := runAsync(ctx, e, behaviors, controlBehavior)
+		r := gatherResult(e, r.Control, candidates, controlBehavior)
+		r.Errors = append(r.Errors, errors...)
+		if err := e.publisher(r); err != nil {
+			r.Errors = append(r.Errors, e.resultErr("publish", err))
+		}
+
+		if len(r.Errors) > 0 {
+			e.errorReporter(r.Errors...)
+		}
+	}(ctx, e)
+
+	return r
+}
+
+func Run(ctx context.Context, e *Experiment, controlBehavior string) Result {
 	r := Result{Experiment: e}
 	if err := e.beforeRun(); err != nil {
 		r.Errors = append(r.Errors, e.resultErr("before_run", err))
 	}
 
 	numCandidates := len(e.behaviors) - 1
-	r.Control = observe(e, name, e.behaviors[name])
+	r.Control = observe(ctx, e, controlBehavior, e.behaviors[controlBehavior])
 	r.Candidates = make([]*Observation, numCandidates)
 	r.Ignored = make([]*Observation, 0, numCandidates)
 	r.Mismatched = make([]*Observation, 0, numCandidates)
@@ -64,11 +114,11 @@ func Run(e *Experiment, name string) Result {
 
 	i := 0
 	for bname, b := range e.behaviors {
-		if bname == name {
+		if bname == controlBehavior {
 			continue
 		}
 
-		c := observe(e, bname, b)
+		c := observe(ctx, e, bname, b)
 		r.Candidates[i] = c
 		i += 1
 		r.Observations[i] = c
@@ -141,30 +191,6 @@ func behaviorNotFound(e *Experiment, name string) error {
 	return fmt.Errorf("Behavior %q not found for experiment %q", name, e.Name)
 }
 
-func observe(e *Experiment, name string, b behaviorFunc) *Observation {
-	o := &Observation{
-		Experiment: e,
-		Name:       name,
-		Started:    time.Now(),
-	}
-
-	if b == nil {
-		b = e.behaviors[name]
-	}
-
-	if b == nil {
-		o.Runtime = time.Since(o.Started)
-		o.Err = behaviorNotFound(e, name)
-	} else {
-		v, err := b()
-		o.Runtime = time.Since(o.Started)
-		o.Value = v
-		o.Err = err
-	}
-
-	return o
-}
-
 type ResultError struct {
 	Operation  string
 	Experiment string
@@ -181,4 +207,124 @@ type MismatchError struct {
 
 func (e MismatchError) Error() string {
 	return fmt.Sprintf("[scientist] experiment %q observations mismatched", e.Result.Experiment.Name)
+}
+
+func runAsync(ctx context.Context, e *Experiment, behaviors []string, controlBehavior string) (*Observation, []*Observation) {
+	var (
+		control    *Observation
+		candidates []*Observation
+		wg         sync.WaitGroup
+	)
+
+	finished := make(chan *Observation, len(behaviors))
+
+	for _, name := range behaviors {
+		wg.Add(1)
+		go func(ctx context.Context, name string) {
+			defer wg.Done()
+			finished <- observe(ctx, e, name, e.behaviors[name])
+		}(ctx, name)
+	}
+	wg.Wait()
+	close(finished)
+
+	for o := range finished {
+		if o.Name == controlBehavior {
+			control = o
+		} else {
+			candidates = append(candidates, o)
+		}
+	}
+
+	return control, candidates
+}
+
+func observe(ctx context.Context, e *Experiment, name string, b behaviorFunc) *Observation {
+	o := &Observation{
+		Experiment: e,
+		Name:       name,
+		Started:    time.Now(),
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			o.Err = errors.New(fmt.Sprintf("recover from bad behavior %s: %v", name, r))
+		}
+	}()
+
+	if b == nil {
+		b = e.behaviors[name]
+	}
+
+	if b == nil {
+		o.Runtime = time.Since(o.Started)
+		o.Err = behaviorNotFound(e, name)
+	} else {
+		v, err := b(ctx)
+		o.Runtime = time.Since(o.Started)
+		o.Value = v
+		o.Err = err
+	}
+
+	return o
+}
+
+func gatherResult(e *Experiment, control *Observation, candidates []*Observation, controlName string) Result {
+	r := Result{
+		Experiment:   e,
+		Control:      control,
+		Candidates:   candidates,
+		Observations: make([]*Observation, len(candidates)+1),
+		Errors:       nil,
+		Ignored:      nil,
+		Mismatched:   nil,
+	}
+	r.Observations = append(r.Observations, control)
+	r.Observations = append(r.Observations, candidates...)
+
+	for _, candidate := range candidates {
+		ok, err := matching(e, r.Control, candidate)
+		if err != nil {
+			ok = false
+			r.Errors = append(r.Errors, e.resultErr("compare", err))
+		}
+		if ok {
+			continue
+		}
+
+		ignored, err := ignoring(e, r.Control, candidate)
+		if err != nil {
+			ignored = false
+			r.Errors = append(r.Errors, e.resultErr("ignore", err))
+		}
+
+		if ignored {
+			r.Ignored = append(r.Ignored, candidate)
+		} else {
+			r.Mismatched = append(r.Mismatched, candidate)
+		}
+	}
+
+	return r
+}
+
+// Shuffle randomizes the behavior access.
+func (e *Experiment) Shuffle(behaviourName string, skip bool) []string {
+	var behaviors []string
+	for name := range e.behaviors {
+		if skip && (behaviourName == name) {
+			continue
+		}
+		behaviors = append(behaviors, name)
+	}
+
+	t := time.Now()
+	rand.Seed(int64(t.Nanosecond()))
+
+	arr := behaviors
+	for i := len(arr) - 1; i > 0; i-- {
+		j := rand.Intn(i)
+		arr[i], arr[j] = arr[j], arr[i]
+	}
+	return arr
 }

--- a/scientist_test.go
+++ b/scientist_test.go
@@ -1,6 +1,7 @@
 package scientist
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"strings"
@@ -9,19 +10,19 @@ import (
 
 func basicExperiment() *Experiment {
 	e := New("basic")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
 
-	e.Try(func() (interface{}, error) {
+	e.Try(func(ctx context.Context) (interface{}, error) {
 		return 2, nil
 	})
 
-	e.Behavior("three", func() (interface{}, error) {
+	e.Behavior("three", func(ctx context.Context) (interface{}, error) {
 		return 3, nil
 	})
 
-	e.Behavior("correct", func() (interface{}, error) {
+	e.Behavior("correct", func(ctx context.Context) (interface{}, error) {
 		return 1, nil
 	})
 	return e
@@ -29,7 +30,7 @@ func basicExperiment() *Experiment {
 
 func TestRun(t *testing.T) {
 	e := basicExperiment()
-	r := Run(e, "control")
+	r := Run(context.Background(), e, "control")
 	if len(r.Errors) != 0 {
 		t.Errorf("Unexpected experiment errors: %v", r.Errors)
 	}
@@ -100,7 +101,7 @@ func TestIgnore(t *testing.T) {
 	e.Ignore(func(control, candidate interface{}) (bool, error) {
 		return candidate == 3, nil
 	})
-	r := Run(e, "control")
+	r := Run(context.Background(), e, "control")
 	if len(r.Errors) != 0 {
 		t.Errorf("Unexpected experiment errors: %v", r.Errors)
 	}
@@ -116,7 +117,7 @@ func TestCompare(t *testing.T) {
 		return control == 1 && candidate == 3, nil
 	})
 
-	r := Run(e, "control")
+	r := Run(context.Background(), e, "control")
 	if len(r.Errors) != 0 {
 		t.Errorf("Unexpected experiment errors: %v", r.Errors)
 	}
@@ -134,7 +135,7 @@ func TestCompareAndIgnore(t *testing.T) {
 	e.Ignore(func(control, candidate interface{}) (bool, error) {
 		return candidate == 1, nil
 	})
-	r := Run(e, "control")
+	r := Run(context.Background(), e, "control")
 	if len(r.Errors) != 0 {
 		t.Errorf("Unexpected experiment errors: %v", r.Errors)
 	}
@@ -146,10 +147,10 @@ func TestCompareAndIgnore(t *testing.T) {
 
 func TestDefaultCleaner(t *testing.T) {
 	e := New("cleaner")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return "booya", nil
 	})
-	r := Run(e, "control")
+	r := Run(context.Background(), e, "control")
 
 	cleaned, err := r.Control.CleanedValue()
 	if err != nil {
@@ -163,13 +164,13 @@ func TestDefaultCleaner(t *testing.T) {
 
 func TestCustomCleaner(t *testing.T) {
 	e := New("cleaner")
-	e.Use(func() (interface{}, error) {
+	e.Use(func(ctx context.Context) (interface{}, error) {
 		return "booya", nil
 	})
 	e.Clean(func(v interface{}) (interface{}, error) {
 		return strings.ToUpper(v.(string)), nil
 	})
-	r := Run(e, "control")
+	r := Run(context.Background(), e, "control")
 
 	cleaned, err := r.Control.CleanedValue()
 	if err != nil {


### PR DESCRIPTION
**Problem**  
The current implementation of the go-scientist package is making synchronous calls to control and candidate behaviors.  The response is being returned to the callee when all the behaviors executed and returned. This is not the behaviour we require when we want to deploy the scientist code under load in staging or production environments.  We require asynchronous experimentation in these scenarios. Refer to java scientist package https://github.com/rawls238/Scientist4J.

**Solution**
Implement RunAsync() and RunAsyncCandidatesOnly() methods to allow asynchronous observations and publishing results.

**Code Changes**
1. Added RunAsync()  
2. Added RunAsyncCandidatesOnly() 

**Checklist** 

- [ ] Unit tests
- [x] Examples
